### PR TITLE
Remove redundant sessionid from telemetry file names

### DIFF
--- a/node_engine/libs/telemetry.py
+++ b/node_engine/libs/telemetry.py
@@ -32,7 +32,7 @@ class Telemetry:
         self.component_key = component_key
 
     def telemetry_storage_key(self) -> str:
-        return f"telemetry_{self.session_id}-{self.flow_key}-{self.component_key}"
+        return f"telemetry_{self.flow_key}-{self.component_key}"
 
     async def capture(self, data) -> None:
         existing_data = (


### PR DESCRIPTION
Considering that all storage is already segregated by directories that match the sessionid
