### PR TITLE
Removes assumption of node_engine NOT being installed as a package in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Node Engine is designed for rapid experimentation and development of new compone
 
 Why not [Semantic Kernel | Promptflow | Autogen | LangChain | etc.]? This framework has been built from the ground up specifically for the experimentation use-case for our team and next areas of investment. Each of those frameworks have their own idiosyncrasies that work well for their use-cases, but don't allow us to run as fast as we can with this approach and the ability for us to quickly extend it to meet our not-yet-discovered needs. Learnings from this framework will be used to inform future work in Semantic Kernel and other areas.
 
-# Concepts
+## Concepts
 
 Detailed [documentation](./docs/node_engine/README.md) of Node Engine and how it works is provided.
 
@@ -56,15 +56,15 @@ When state must be provided to a component, there are a few recommended approach
 
 It is recommended to avoid storing flow-level state in the component config, as it is designed to be used for configuration and not state. Instead, update the context with the state and it will be passed to the remaining components in the flow.
 
-# Quickstart
+## Quickstart
 
-## Prerequisites
+### Prerequisites
 
 The steps below assume your dev environment has Python 3.10.11+ or 3.11+ installed and available in the console. You can execute this command to check your version: `python3 --version`.
 
 It's highly recommended to develop with Node Engine using python virtual environments, with all the benefits that come. See https://docs.python.org/3/library/venv.html for details.
 
-## Install Node Engine and dependencies
+### Install Node Engine and dependencies
 
 These steps will set up all of the prerequisites for running the Node Engine
 service locally, along with anything needed for the example scripts and notebooks.
@@ -103,7 +103,7 @@ you can skip to the next section and start Node Engine service.
 
 - Edit `.env` as needed, adding your credentials.
 
-## Start Node Engine service
+### Start Node Engine service
 
 Unless Node Engine service is already running, open a terminal console and run
 the following commands from the root of the project:
@@ -119,12 +119,12 @@ the following commands from the root of the project:
 - Start local Node Engine service. The service defaults to port 8000.
 
       # alternative with VS Code debugger:
-      #    Shift+Ctrl+D and choose 'Node Engine Service'
+      #   Shift+Ctrl+D and choose 'Node Engine Service'
       node-engine-service --registry-root examples
 
-# Quick Tests
+## Quick Tests
 
-## #1 Run sample flow from command line
+### #1 Run sample flow from command line
 
 - After starting the service, open a new console.
 - Activate the virtual environment:
@@ -141,7 +141,7 @@ the following commands from the root of the project:
 
 - You should see a sample JSON output on screen, without errors, and a context containing "Hello World".
 
-## #2 Test SSE (server side events) via Postman
+### #2 Test SSE (server side events) via Postman
 
 - Launch Postman and create a new GET request with the following url:
   - `http://127.0.0.1:8000/sse?session_id=my-session-12345&connection_id=my-connection-12345`
@@ -153,12 +153,12 @@ the following commands from the root of the project:
 
   ![Alt text](docs/quickstart.png)
 
-# Next steps
+## Next steps
 
 Once the service is running, you can run the example [scripts](../examples/scripts/)
 and [notebooks](../examples/notebooks/).
 
-## Invoke a flow from command line
+### Invoke a flow from command line
 
 This [invoke-flow.py](examples/scripts/invoke-flow.py) script loads a flow definition and send it to the service to be executed. The examples/definitions folder contains some examples.
 
@@ -169,11 +169,11 @@ Example:
 
       python3 examples/scripts/invoke-flow.py examples/definitions/simple-cognition.json --session-id sid123 --log-level debug --stream-log
 
-## Simple Chat client
+### Simple Chat client
 
 The examples folder contain a sample chat app with a custom UI to chat with OpenAI models, see the [documentation here](examples/apps/simple-chat-client/README.md) to test it. In this case you won't need to start the service because the app starts the service automatically.
 
-## Watch service logs
+### Watch service logs
 
 This [debug-service.py](examples/scripts/debug-service.py) script attaches to the service and emits log events for a specific session.
 
@@ -187,7 +187,7 @@ Example:
 
 - Interact with the chat app and observe logs coming through in the console.
 
-## Develop your apps
+### Develop your apps
 
 To experiment with developing new apps, scripts, flows and components, see the
 [Development guide](docs/DEVELOPMENT.md) for more details.

--- a/node_engine/libs/component_loaders/module_component_loader.py
+++ b/node_engine/libs/component_loaders/module_component_loader.py
@@ -1,9 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import importlib
-import os
-import pathlib
-import traceback
 
 from node_engine.libs.component_loaders.component_loader import ComponentLoader
 from node_engine.libs.node_engine_component import NodeEngineComponent
@@ -18,61 +15,15 @@ class ModuleComponentLoader:
         component_key: str,
         module_name: str,
         class_name: str,
-        registry_root: str,
         executor: FlowExecutor,
         tunnel_authorization: str | None = None,
     ) -> NodeEngineComponent:
-        try:
-            module = importlib.import_module(module_name)
-
-            return ComponentLoader.load(
-                flow_definition,
-                component_key,
-                module,
-                class_name,
-                executor,
-                tunnel_authorization,
-            )
-        except ModuleNotFoundError as e:
-            if e.name != module_name:
-                stacktrace = traceback.format_exc()
-                raise Exception(
-                    f"Error importing module '{module_name}': {e}. {stacktrace}"
-                )
-
-            pass
-
-        # Check if module exists as a `components` dir off of registry_root.
-        # This is the recommended way to set up Node Engine projects.
-        if os.path.isfile(
-            os.path.join(registry_root, "components", f"{module_name}.py")
-        ):
-            # Assumes the path that includes the `node_engine` dir is in the
-            # system path which is how we recommend setting up Node Engine
-            # projects.
-            path_parts = pathlib.Path(registry_root).parts[-2:] + ("components",)
-            # convert to dot notation
-            package = ".".join(path_parts)
-
-            try:
-                name = f".{module_name}"
-                module = importlib.import_module(name, package)
-            except Exception as exception:
-                stacktrace = traceback.format_exc()
-                raise Exception(
-                    f"Error importing module '{module_name}': {exception}. Trace: {stacktrace}"
-                )
-
-            return ComponentLoader.load(
-                flow_definition,
-                component_key,
-                module,
-                class_name,
-                executor,
-                tunnel_authorization,
-            )
-
-        stacktrace = traceback.format_exc()
-        raise Exception(
-            f"Module '{module_name}' not found in local file components dir: {stacktrace}"
+        module = importlib.import_module(module_name)
+        return ComponentLoader.load(
+            flow_definition,
+            component_key,
+            module,
+            class_name,
+            executor,
+            tunnel_authorization,
         )


### PR DESCRIPTION
… module loader.

<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

The module loader and registry root functionality assumes the node_engine is _not_ installed as a package but rather as a directory within a project. This was a reasonable assumption earlier and the relative module loading, searching for modules in parent directories, and merging registry.json files up parent directories was nice for the situation where multiple node_engine projects/scripts were to be found in the same repo. 

Now, though, the main expectation is that node_engine will be installed as a package... one per project. The assumption we were making about the node_engine being found in the project dir is no longer true, the functionality was broken, and the need for these features is no longer evident. 

## High level description (Approach, Design)

This PR removes relative module loading, module search in parent directories, and registry.json file merging from parent directories. Now, the full module package path must be specified in the registry.json and only one registry.json file may be used per node_engine instance.

